### PR TITLE
V201609 - v201708

### DIFF
--- a/ad_group.go
+++ b/ad_group.go
@@ -81,7 +81,7 @@ type AdGroupLabelOperations map[string][]AdGroupLabel
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupService#get
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupService#get
 //
 func (s *AdGroupService) Get(selector Selector) (adGroups []AdGroup, totalCount int64, err error) {
 	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
@@ -128,7 +128,7 @@ func (s *AdGroupService) Get(selector Selector) (adGroups []AdGroup, totalCount 
 //          CampaignId:  campaignId,
 //          BiddingStrategyConfiguration: []gads.BiddingStrategyConfiguration{
 //            gads.BiddingStrategyConfiguration{
-//              StrategyType: "MANUAL_CPC",
+//              StrategyType: "NONE",
 //              Bids: []gads.Bid{
 //                gads.Bid{
 //                  Type:   "CpcBid",
@@ -150,7 +150,7 @@ func (s *AdGroupService) Get(selector Selector) (adGroups []AdGroup, totalCount 
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupService#mutate
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupService#mutate
 //
 func (s *AdGroupService) Mutate(adGroupOperations AdGroupOperations) (adGroups []AdGroup, err error) {
 	type adGroupOperation struct {
@@ -210,7 +210,7 @@ func (s *AdGroupService) Mutate(adGroupOperations AdGroupOperations) (adGroups [
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupService#mutateLabel
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupService#mutateLabel
 //
 func (s *AdGroupService) MutateLabel(adGroupLabelOperations AdGroupLabelOperations) (adGroupLabels []AdGroupLabel, err error) {
 	type adGroupLabelOperation struct {
@@ -254,7 +254,7 @@ func (s *AdGroupService) MutateLabel(adGroupLabelOperations AdGroupLabelOperatio
 
 // Query documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupService#query
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupService#query
 //
 func (s *AdGroupService) Query(query string) (adGroups []AdGroup, totalCount int64, err error) {
 

--- a/ad_group_ad.go
+++ b/ad_group_ad.go
@@ -8,80 +8,97 @@ type AdGroupAdService struct {
 	Auth
 }
 
+type AdGroupAdPolicySummary struct {
+	TopicEntries       []PolicyTopicEntry `xml:"policyTopicEntries,omitempty"`
+	ReviewState        string             `xml:"reviewState,omitempty"`
+	DenormalizedStatus string             `xml:"denormalizedStatus,omitempty"`
+	ApprovalStatus     string             `xml:"combinedApprovalStatus,omitempty"`
+}
+
+type PolicyTopicEntry struct {
+	Type         string                  `xml:"policyTopicEntryType,omitempty"`
+	Evidences    []PolicyTopicEvidence   `xml:"policyTopicEvidences,omitempty"`
+	PConstraints []PolicyTopicConstraint `xml:"policyTopicConstraints,omitempty"`
+	ID           string                  `xml:"policyTopicId,omitempty"`
+	Name         string                  `xml:"policyTopicName,omitempty"`
+}
+
+type PolicyTopicEvidence struct {
+	Type string `xml:"policyTopicEvidenceType,omitempty"`
+	Text string `xml:"evidenceText,omitempty"`
+}
+
+type PolicyTopicConstraint struct {
+	ConstraintType string `xml:"constraintType,omitempty"`
+	Type           string `xml:"PolicyTopicConstraint.Type,omitempty"`
+}
+
 type AppUrl struct {
 	Url    string `xml:"url"`
 	OsType string `xml:"osType"` // "OS_TYPE_IOS", "OS_TYPE_ANDROID", "UNKNOWN"
 }
 
 type TextAd struct {
-	AdGroupId            int64             `xml:"-"`
-	Id                   int64             `xml:"id,omitempty"`
-	Url                  string            `xml:"url"`
-	DisplayUrl           string            `xml:"displayUrl"`
-	FinalUrls            []string          `xml:"finalUrls,omitempty"`
-	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
-	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
-	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
-	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type                 string            `xml:"type,omitempty"`
-	DevicePreference     int64             `xml:"devicePreference,omitempty"`
-	Headline             string            `xml:"headline"`
-	Description1         string            `xml:"description1"`
-	Description2         string            `xml:"description2"`
-	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
-	Labels               []Label           `xml:"-"`
+	AdGroupId           int64                   `xml:"-"`
+	Id                  int64                   `xml:"id,omitempty"`
+	Url                 string                  `xml:"url"`
+	DisplayUrl          string                  `xml:"displayUrl"`
+	FinalUrls           []string                `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string                `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls        []AppUrl                `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate string                  `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters       `xml:"urlCustomParameters,omitempty"`
+	Type                string                  `xml:"type,omitempty"`
+	DevicePreference    int64                   `xml:"devicePreference,omitempty"`
+	Headline            string                  `xml:"headline"`
+	Description1        string                  `xml:"description1"`
+	Description2        string                  `xml:"description2"`
+	Status              string                  `xml:"-"`
+	PolicySummary       *AdGroupAdPolicySummary `xml:"-"`
+	Labels              []Label                 `xml:"-"`
 }
 
 type ExpandedTextAd struct {
-	AdGroupId            int64                  `xml:"-"`
-	Id                   int64                  `xml:"id,omitempty"`
-	FinalUrls            []string               `xml:"finalUrls,omitempty"`
-	FinalMobileUrls      []string               `xml:"finalMobileUrls,omitempty"`
-	TrackingUrlTemplate  string                 `xml:"trackingUrlTemplate,omitempty"`
-	UrlCustomParameters  *CustomParameters      `xml:"urlCustomParameters,omitempty"`
-	Type                 string                 `xml:"type,omitempty"`
-	HeadlinePart1        string                 `xml:"headlinePart1"`
-	HeadlinePart2        string                 `xml:"headlinePart2"`
-	Description          string                 `xml:"description"`
-	Path1                string                 `xml:"path1"`
-	Path2                string                 `xml:"path2"`
-	ExperimentData       *AdGroupExperimentData `xml:"-"`
-	Status               string                 `xml:"-"`
-	ApprovalStatus       string                 `xml:"-"`
-	Trademarks           []string               `xml:"-"`
-	DisapprovalReasons   []string               `xml:"-"`
-	TrademarkDisapproved bool                   `xml:"-"`
-	Labels               []Label                `xml:"-"`
-	BaseCampaignId       *int64                 `xml:"-"`
-	BaseAdGroupId        *int64                 `xml:"-"`
+	AdGroupId           int64                   `xml:"-"`
+	Id                  int64                   `xml:"id,omitempty"`
+	FinalUrls           []string                `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string                `xml:"finalMobileUrls,omitempty"`
+	TrackingUrlTemplate string                  `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters       `xml:"urlCustomParameters,omitempty"`
+	Type                string                  `xml:"type,omitempty"`
+	HeadlinePart1       string                  `xml:"headlinePart1"`
+	HeadlinePart2       string                  `xml:"headlinePart2"`
+	Description         string                  `xml:"description"`
+	Path1               string                  `xml:"path1"`
+	Path2               string                  `xml:"path2"`
+	ExperimentData      *AdGroupExperimentData  `xml:"-"`
+	Status              string                  `xml:"-"`
+	PolicySummary       *AdGroupAdPolicySummary `xml:"-"`
+	Labels              []Label                 `xml:"-"`
+	BaseCampaignId      *int64                  `xml:"-"`
+	BaseAdGroupId       *int64                  `xml:"-"`
 }
 
 type ResponsiveDisplayAd struct {
-	AdGroupId            int64                 `xml:"-"`
-	Id                   int64                 `xml:"id,omitempty"`
-	FinalUrls            []string              `xml:"finalUrls,omitempty"`
-	FinalMobileUrls      []string              `xml:"finalMobileUrls,omitempty"`
-	TrackingUrlTemplate  string                `xml:"trackingUrlTemplate,omitempty"`
-	UrlCustomParameters  *CustomParameters     `xml:"urlCustomParameters,omitempty"`
-	Type                 string                `xml:"type,omitempty"`
-	MarketingImage       Media                 `xml:"marketingImage"`
-	LogoImage            Media                 `xml:"logoImage"`
-	ShortHeadline        string                `xml:"shortHeadline"`
-	LongHeadline         string                `xml:"longHeadline"`
-	Description          string                `xml:"description"`
-	BusinessName         string                `xml:"businessName"`
-	ExperimentData       AdGroupExperimentData `xml:"-"`
-	Status               string                `xml:"-"`
-	ApprovalStatus       string                `xml:"-"`
-	Trademarks           []string              `xml:"-"`
-	DisapprovalReasons   []string              `xml:"-"`
-	TrademarkDisapproved bool                  `xml:"-"`
-	Labels               []Label               `xml:"-"`
-	BaseCampaignId       int64                 `xml:"-"`
-	BaseAdGroupId        int64                 `xml:"-"`
+	AdGroupId           int64                   `xml:"-"`
+	Id                  int64                   `xml:"id,omitempty"`
+	FinalUrls           []string                `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string                `xml:"finalMobileUrls,omitempty"`
+	TrackingUrlTemplate string                  `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters       `xml:"urlCustomParameters,omitempty"`
+	Type                string                  `xml:"type,omitempty"`
+	MarketingImage      Media                   `xml:"marketingImage"`
+	LogoImage           Media                   `xml:"logoImage"`
+	ShortHeadline       string                  `xml:"shortHeadline"`
+	LongHeadline        string                  `xml:"longHeadline"`
+	Description         string                  `xml:"description"`
+	BusinessName        string                  `xml:"businessName"`
+	ExperimentData      AdGroupExperimentData   `xml:"-"`
+	Status              string                  `xml:"-"`
+	Labels              []Label                 `xml:"-"`
+	PolicySummary       *AdGroupAdPolicySummary `xml:"-"`
+	BaseCampaignId      int64                   `xml:"-"`
+	BaseAdGroupId       int64                   `xml:"-"`
 }
 
 type AdGroupExperimentData struct {
@@ -91,51 +108,47 @@ type AdGroupExperimentData struct {
 }
 
 type ImageAd struct {
-	AdGroupId            int64             `xml:"-"`
-	Id                   int64             `xml:"id,omitempty"`
-	Url                  string            `xml:"url"`
-	DisplayUrl           string            `xml:"displayUrl"`
-	FinalUrls            []string          `xml:"finalUrls,omitempty"`
-	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
-	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
-	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
-	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type                 string            `xml:"type,omitempty"`
-	DevicePreference     int64             `xml:"devicePreference,omitempty"`
-	Image                int64             `xml:"imageId"`
-	Name                 string            `xml:"name"`
-	AdToCopyImageFrom    int64             `xml:"adToCopyImageFrom"`
-	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
-	Labels               []Label           `xml:"-"`
+	AdGroupId           int64                   `xml:"-"`
+	Id                  int64                   `xml:"id,omitempty"`
+	Url                 string                  `xml:"url"`
+	DisplayUrl          string                  `xml:"displayUrl"`
+	FinalUrls           []string                `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string                `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls        []AppUrl                `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate string                  `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters       `xml:"urlCustomParameters,omitempty"`
+	Type                string                  `xml:"type,omitempty"`
+	DevicePreference    int64                   `xml:"devicePreference,omitempty"`
+	Image               int64                   `xml:"imageId"`
+	Name                string                  `xml:"name"`
+	AdToCopyImageFrom   int64                   `xml:"adToCopyImageFrom"`
+	Status              string                  `xml:"-"`
+	Labels              []Label                 `xml:"-"`
+	PolicySummary       *AdGroupAdPolicySummary `xml:"-"`
 }
 
 type MobileAd struct {
-	AdGroupId            int64             `xml:"-"`
-	Id                   int64             `xml:"id,omitempty"`
-	Url                  string            `xml:"url"`
-	DisplayUrl           string            `xml:"displayUrl"`
-	FinalUrls            []string          `xml:"finalUrls,omitempty"`
-	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
-	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
-	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
-	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type                 string            `xml:"type,omitempty"`
-	DevicePreference     int64             `xml:"devicePreference,omitempty"`
-	Headline             string            `xml:"headline"`
-	Description          string            `xml:"description"`
-	MarkupLanguages      []string          `xml:"markupLanguages"`
-	MobileCarriers       []string          `xml:"mobileCarriers"`
-	BusinessName         string            `xml:"businessName"`
-	CountryCode          string            `xml:"countryCode"`
-	PhoneNumber          string            `xml:"phoneNumber"`
-	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
-	Labels               []Label           `xml:"-"`
+	AdGroupId           int64                   `xml:"-"`
+	Id                  int64                   `xml:"id,omitempty"`
+	Url                 string                  `xml:"url"`
+	DisplayUrl          string                  `xml:"displayUrl"`
+	FinalUrls           []string                `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string                `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls        []AppUrl                `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate string                  `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters       `xml:"urlCustomParameters,omitempty"`
+	Type                string                  `xml:"type,omitempty"`
+	DevicePreference    int64                   `xml:"devicePreference,omitempty"`
+	Headline            string                  `xml:"headline"`
+	Description         string                  `xml:"description"`
+	MarkupLanguages     []string                `xml:"markupLanguages"`
+	MobileCarriers      []string                `xml:"mobileCarriers"`
+	BusinessName        string                  `xml:"businessName"`
+	CountryCode         string                  `xml:"countryCode"`
+	PhoneNumber         string                  `xml:"phoneNumber"`
+	Status              string                  `xml:"-"`
+	Labels              []Label                 `xml:"-"`
+	PolicySummary       *AdGroupAdPolicySummary `xml:"-"`
 }
 
 type TemplateElementField struct {
@@ -151,57 +164,69 @@ type TemplateElement struct {
 }
 
 type TemplateAd struct {
-	AdGroupId            int64             `xml:"-"`
-	Id                   int64             `xml:"id,omitempty"`
-	Url                  string            `xml:"url"`
-	DisplayUrl           string            `xml:"displayUrl"`
-	FinalUrls            []string          `xml:"finalUrls,omitempty"`
-	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
-	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
-	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
-	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type                 string            `xml:"type,omitempty"`
-	DevicePreference     int64             `xml:"devicePreference,omitempty"`
-	TemplateId           int64             `xml:"templateId"`
-	AdUnionId            int64             `xml:"adUnionId>id"`
-	TemplateElements     []TemplateElement `xml:"templateElements"`
-	Dimensions           []Dimensions      `xml:"dimensions"`
-	Name                 string            `xml:"name"`
-	Duration             int64             `xml:"duration"`
-	originAdId           *int64            `xml:"originAdId"`
-	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
-	Labels               []Label           `xml:"-"`
+	AdGroupId           int64                   `xml:"-"`
+	Id                  int64                   `xml:"id,omitempty"`
+	Url                 string                  `xml:"url"`
+	DisplayUrl          string                  `xml:"displayUrl"`
+	FinalUrls           []string                `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string                `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls        []AppUrl                `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate string                  `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters       `xml:"urlCustomParameters,omitempty"`
+	Type                string                  `xml:"type,omitempty"`
+	DevicePreference    int64                   `xml:"devicePreference,omitempty"`
+	TemplateId          int64                   `xml:"templateId"`
+	AdUnionId           int64                   `xml:"adUnionId>id"`
+	TemplateElements    []TemplateElement       `xml:"templateElements"`
+	Dimensions          []Dimensions            `xml:"dimensions"`
+	Name                string                  `xml:"name"`
+	Duration            int64                   `xml:"duration"`
+	originAdId          *int64                  `xml:"originAdId"`
+	Status              string                  `xml:"-"`
+	Labels              []Label                 `xml:"-"`
+	PolicySummary       *AdGroupAdPolicySummary `xml:"-"`
 }
 
 type DynamicSearchAd struct {
-	AdGroupId            int64             `xml:"-"`
-	Id                   int64             `xml:"id,omitempty"`
-	Url                  string            `xml:"url"`
-	DisplayUrl           string            `xml:"displayUrl"`
-	FinalUrls            []string          `xml:"finalUrls,omitempty"`
-	FinalMobileUrls      []string          `xml:"finalMobileUrls,omitempty"`
-	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
-	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
-	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type                 string            `xml:"type,omitempty"`
-	DevicePreference     int64             `xml:"devicePreference,omitempty"`
-	Status               string            `xml:"-"`
-	ApprovalStatus       string            `xml:"-"`
-	DisapprovalReasons   []string          `xml:"-"`
-	TrademarkDisapproved bool              `xml:"-"`
+	AdGroupId           int64                   `xml:"-"`
+	Id                  int64                   `xml:"id,omitempty"`
+	Url                 string                  `xml:"url"`
+	DisplayUrl          string                  `xml:"displayUrl"`
+	FinalUrls           []string                `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string                `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls        []AppUrl                `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate string                  `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters       `xml:"urlCustomParameters,omitempty"`
+	Type                string                  `xml:"type,omitempty"`
+	DevicePreference    int64                   `xml:"devicePreference,omitempty"`
+	Status              string                  `xml:"-"`
+	PolicySummary       *AdGroupAdPolicySummary `xml:"-"`
+}
+
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupAdService.ExpandedDynamicSearchAd
+type ExpandedDynamicSearchAd struct {
+	AdGroupId           int64                   `xml:"-"`
+	Id                  int64                   `xml:"id,omitempty"`
+	Url                 string                  `xml:"url"`
+	DisplayUrl          string                  `xml:"displayUrl"`
+	FinalUrls           []string                `xml:"finalUrls,omitempty"`
+	FinalMobileUrls     []string                `xml:"finalMobileUrls,omitempty"`
+	FinalAppUrls        []AppUrl                `xml:"finalAppUrls,omitempty"`
+	TrackingUrlTemplate string                  `xml:"trackingUrlTemplate,omitempty"`
+	UrlCustomParameters *CustomParameters       `xml:"urlCustomParameters,omitempty"`
+	Type                string                  `xml:"type,omitempty"`
+	DevicePreference    int64                   `xml:"devicePreference,omitempty"`
+	Description         string                  `xml:"description"`
+	Status              string                  `xml:"-"`
+	PolicySummary       *AdGroupAdPolicySummary `xml:"-"`
 }
 
 type ProductAd struct {
-	AdGroupId            int64    `xml:"-"`
-	Id                   int64    `xml:"id,omitempty"`
-	Type                 string   `xml:"type,omitempty"`
-	Status               string   `xml:"-"`
-	ApprovalStatus       string   `xml:"-"`
-	DisapprovalReasons   []string `xml:"-"`
-	TrademarkDisapproved bool     `xml:"-"`
+	AdGroupId     int64                   `xml:"-"`
+	Id            int64                   `xml:"id,omitempty"`
+	Type          string                  `xml:"type,omitempty"`
+	Status        string                  `xml:"-"`
+	PolicySummary *AdGroupAdPolicySummary `xml:"-"`
 }
 
 type AdGroupAdOperations map[string]AdGroupAds
@@ -282,7 +307,7 @@ type AdUrlUpgrade struct {
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#get
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupAdService#get
 //
 func (s AdGroupAdService) Get(selector Selector) (adGroupAds AdGroupAds, totalCount int64, err error) {
 	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
@@ -344,7 +369,7 @@ func (s AdGroupAdService) Get(selector Selector) (adGroupAds AdGroupAds, totalCo
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#mutate
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupAdService#mutate
 //
 func (s *AdGroupAdService) Mutate(adGroupAdOperations AdGroupAdOperations) (adGroupAds AdGroupAds, err error) {
 	type adGroupAdOperation struct {
@@ -403,7 +428,7 @@ func (s *AdGroupAdService) Mutate(adGroupAdOperations AdGroupAdOperations) (adGr
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#mutateLabel
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupAdService#mutateLabel
 //
 func (s *AdGroupAdService) MutateLabel(adGroupAdLabelOperations AdGroupAdLabelOperations) (adGroupAdLabels []AdGroupAdLabel, err error) {
 	type adGroupAdLabelOperation struct {
@@ -449,18 +474,8 @@ func (s *AdGroupAdService) MutateLabel(adGroupAdLabelOperations AdGroupAdLabelOp
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#query
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupAdService#query
 //
 func (s *AdGroupAdService) Query(query string) (adGroupAds AdGroupAds, totalCount int64, err error) {
 	return adGroupAds, totalCount, ERROR_NOT_YET_IMPLEMENTED
-}
-
-// Query is not yet implemented
-//
-// Relevant documentation
-//
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupAdService#upgradeUrl
-//
-func (s *AdGroupAdService) UpgradeUrl(adUrlUpgrades []AdUrlUpgrade) (adGroupAds AdGroupAds, err error) {
-	return adGroupAds, ERROR_NOT_YET_IMPLEMENTED
 }

--- a/ad_group_ads.go
+++ b/ad_group_ads.go
@@ -47,12 +47,10 @@ func (a1 AdGroupAds) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 func (aga *AdGroupAds) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	typeName := xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"}
 	var adGroupId int64
-	var status, approvalStatus string
-	var disapprovalReasons []string
-	var trademarkDisapproved bool
+	var status string
 	var labels []Label
 	var experimentData *AdGroupExperimentData
-	var trademarks []string
+	var policySummary *AdGroupAdPolicySummary
 	var baseCampaignId *int64
 	var baseAdGroupId *int64
 	var ad interface{}
@@ -109,6 +107,12 @@ func (aga *AdGroupAds) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) er
 					if err != nil {
 						return err
 					}
+				case "ExpandedDynamicSearchAd":
+					a := ExpandedDynamicSearchAd{AdGroupId: adGroupId}
+					err := dec.DecodeElement(&a, &start)
+					if err != nil {
+						return err
+					}
 				case "ProductAd":
 					a := ProductAd{AdGroupId: adGroupId}
 					err := dec.DecodeElement(&a, &start)
@@ -123,28 +127,13 @@ func (aga *AdGroupAds) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) er
 				if err != nil {
 					return err
 				}
+			case "policySummary", "PolicySummary":
+				err := dec.DecodeElement(&policySummary, &start)
+				if err != nil {
+					return err
+				}
 			case "status":
 				err := dec.DecodeElement(&status, &start)
-				if err != nil {
-					return err
-				}
-			case "approvalStatus":
-				err := dec.DecodeElement(&approvalStatus, &start)
-				if err != nil {
-					return err
-				}
-			case "trademarks":
-				err := dec.DecodeElement(&trademarks, &start)
-				if err != nil {
-					return err
-				}
-			case "disapprovalReasons":
-				err := dec.DecodeElement(&disapprovalReasons, &start)
-				if err != nil {
-					return err
-				}
-			case "trademarkDisapproved":
-				err := dec.DecodeElement(&trademarkDisapproved, &start)
 				if err != nil {
 					return err
 				}
@@ -172,44 +161,34 @@ func (aga *AdGroupAds) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) er
 	switch a := ad.(type) {
 	case TextAd:
 		a.Status = status
-		a.ApprovalStatus = approvalStatus
-		a.DisapprovalReasons = disapprovalReasons
-		a.TrademarkDisapproved = trademarkDisapproved
+		a.PolicySummary = policySummary
 		*aga = append(*aga, a)
 	case ExpandedTextAd:
 		a.ExperimentData = experimentData
 		a.Status = status
-		a.ApprovalStatus = approvalStatus
-		a.Trademarks = trademarks
-		a.DisapprovalReasons = disapprovalReasons
-		a.TrademarkDisapproved = trademarkDisapproved
+		a.PolicySummary = policySummary
 		a.Labels = labels
 		a.BaseCampaignId = baseCampaignId
 		a.BaseAdGroupId = baseAdGroupId
 		*aga = append(*aga, a)
 	case ImageAd:
 		a.Status = status
-		a.ApprovalStatus = approvalStatus
-		a.DisapprovalReasons = disapprovalReasons
-		a.TrademarkDisapproved = trademarkDisapproved
+		a.PolicySummary = policySummary
 		*aga = append(*aga, a)
 	case TemplateAd:
 		a.Status = status
-		a.ApprovalStatus = approvalStatus
-		a.DisapprovalReasons = disapprovalReasons
-		a.TrademarkDisapproved = trademarkDisapproved
+		a.PolicySummary = policySummary
 		*aga = append(*aga, a)
 	case DynamicSearchAd:
 		a.Status = status
-		a.ApprovalStatus = approvalStatus
-		a.DisapprovalReasons = disapprovalReasons
-		a.TrademarkDisapproved = trademarkDisapproved
+		a.PolicySummary = policySummary
+		*aga = append(*aga, a)
+	case ExpandedDynamicSearchAd:
+		a.Status = status
 		*aga = append(*aga, a)
 	case ProductAd:
 		a.Status = status
-		a.ApprovalStatus = approvalStatus
-		a.DisapprovalReasons = disapprovalReasons
-		a.TrademarkDisapproved = trademarkDisapproved
+		a.PolicySummary = policySummary
 		*aga = append(*aga, a)
 	}
 	return nil

--- a/ad_group_criterion.go
+++ b/ad_group_criterion.go
@@ -140,7 +140,7 @@ type AdGroupCriterionOperations map[string]AdGroupCriterions
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupCriterionService#get
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupCriterionService#get
 //
 func (s AdGroupCriterionService) Get(selector Selector) (adGroupCriterions AdGroupCriterions, totalCount int64, err error) {
 	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
@@ -202,7 +202,7 @@ func (s AdGroupCriterionService) Get(selector Selector) (adGroupCriterions AdGro
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupCriterionService#mutate
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupCriterionService#mutate
 //
 func (s *AdGroupCriterionService) Mutate(adGroupCriterionOperations AdGroupCriterionOperations) (adGroupCriterions AdGroupCriterions, err error) {
 	type adGroupCriterionOperation struct {
@@ -263,7 +263,7 @@ func (s *AdGroupCriterionService) Mutate(adGroupCriterionOperations AdGroupCrite
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupCriterionService#mutateLabel
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupCriterionService#mutateLabel
 //
 func (s *AdGroupCriterionService) MutateLabel(adGroupCriterionLabelOperations AdGroupCriterionLabelOperations) (adGroupCriterionLabels []AdGroupCriterionLabel, err error) {
 	type adGroupCriterionLabelOperation struct {
@@ -307,7 +307,7 @@ func (s *AdGroupCriterionService) MutateLabel(adGroupCriterionLabelOperations Ad
 
 // Query documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupCriterionService#query
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupCriterionService#query
 //
 func (s *AdGroupCriterionService) Query(query string) (adGroupCriterions AdGroupCriterions, totalCount int64, err error) {
 

--- a/ad_group_extension.go
+++ b/ad_group_extension.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 )
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService#query
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService#query
 type AdGroupExtensionSettingService struct {
 	Auth
 }
@@ -13,17 +13,17 @@ func NewAdGroupExtensionSettingService(auth *Auth) *AdGroupExtensionSettingServi
 	return &AdGroupExtensionSettingService{Auth: *auth}
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.AdGroupExtensionSetting
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.AdGroupExtensionSetting
 // An AdGroupExtensionSetting is used to add or modify extensions being served for the specified ad group.
 type AdGroupExtensionSetting struct {
-	AdGroupId        int64            `xml:"https://adwords.google.com/api/adwords/cm/v201609 adGroupId,omitempty"`
-	ExtensionType    FeedType         `xml:"https://adwords.google.com/api/adwords/cm/v201609 extensionType,omitempty"`
-	ExtensionSetting ExtensionSetting `xml:"https://adwords.google.com/api/adwords/cm/v201609 extensionSetting,omitempty"`
+	AdGroupId        int64            `xml:"https://adwords.google.com/api/adwords/cm/v201708 adGroupId,omitempty"`
+	ExtensionType    FeedType         `xml:"https://adwords.google.com/api/adwords/cm/v201708 extensionType,omitempty"`
+	ExtensionSetting ExtensionSetting `xml:"https://adwords.google.com/api/adwords/cm/v201708 extensionSetting,omitempty"`
 }
 
 type AdGroupExtensionSettingOperations map[string][]AdGroupExtensionSetting
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService#query
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService#query
 func (s *AdGroupExtensionSettingService) Query(query string) (settings []AdGroupExtensionSetting, totalCount int64, err error) {
 	respBody, err := s.Auth.request(
 		adGroupExtensionSettingServiceUrl,
@@ -53,7 +53,7 @@ func (s *AdGroupExtensionSettingService) Query(query string) (settings []AdGroup
 	return getResp.Settings, getResp.Size, err
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService#mutate
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService#mutate
 func (s *AdGroupExtensionSettingService) Mutate(settingsOperations AdGroupExtensionSettingOperations) (settings []AdGroupExtensionSetting, err error) {
 	type settingOperations struct {
 		Action  string                  `xml:"operator"`

--- a/ad_group_feed.go
+++ b/ad_group_feed.go
@@ -23,7 +23,7 @@ type AdGroupFeed struct {
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#get
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupFeedService#get
 //
 func (s AdGroupFeedService) Get(selector Selector) (adGroupFeeds []AdGroupFeed, err error) {
 	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED
@@ -33,7 +33,7 @@ func (s AdGroupFeedService) Get(selector Selector) (adGroupFeeds []AdGroupFeed, 
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#mutate
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupFeedService#mutate
 //
 func (s *AdGroupFeedService) Mutate(adGroupFeedOperations AdGroupFeedOperations) (adGroupFeeds []AdGroupFeed, err error) {
 	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED
@@ -43,7 +43,7 @@ func (s *AdGroupFeedService) Mutate(adGroupFeedOperations AdGroupFeedOperations)
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdGroupFeedService#query
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupFeedService#query
 //
 func (s *AdGroupFeedService) Query(query string) (adGroupFeeds []AdGroupFeed, err error) {
 	return adGroupFeeds, ERROR_NOT_YET_IMPLEMENTED

--- a/ad_param.go
+++ b/ad_param.go
@@ -20,7 +20,7 @@ func NewAdParamService(auth *Auth) *AdParamService {
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/AdParamService#get
+//     https://developers.google.com/adwords/api/docs/reference/v201708/AdParamService#get
 //
 func (s AdParamService) Get(selector Selector) (adParams []AdParam, err error) {
 	return adParams, ERROR_NOT_YET_IMPLEMENTED

--- a/base.go
+++ b/base.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	version               = "v201609"
+	version               = "v201708"
 	rootUrl               = "https://adwords.google.com/api/adwords/cm/"
 	baseUrl               = "https://adwords.google.com/api/adwords/cm/" + version
 	rootMcmUrl            = "https://adwords.google.com/api/adwords/mcm/"
@@ -116,8 +116,8 @@ type OrderBy struct {
 }
 
 type Paging struct {
-	Offset int64 `xml:"https://adwords.google.com/api/adwords/cm/v201609 startIndex"`
-	Limit  int64 `xml:"https://adwords.google.com/api/adwords/cm/v201609 numberResults"`
+	Offset int64 `xml:"https://adwords.google.com/api/adwords/cm/v201708 startIndex"`
+	Limit  int64 `xml:"https://adwords.google.com/api/adwords/cm/v201708 numberResults"`
 }
 
 type Selector struct {
@@ -138,32 +138,32 @@ type Options struct {
 	CustomerID string
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.DayOfWeek
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.DayOfWeek
 // Days of the week.
 // MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
 type DayOfWeek string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.MinuteOfHour
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.MinuteOfHour
 // Minutes in an hour. Currently only 0, 15, 30, and 45 are supported
 // ZERO, FIFTEEN, THIRTY, FORTY_FIVE
 type MinuteOfHour string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.GeoRestriction
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.GeoRestriction
 // A restriction used to determine if the request context's geo should be matched.
 // UNKNOWN, LOCATION_OF_PRESENCE
 type GeoRestriction string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.PolicyData
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.PolicyData
 // Approval and policy information attached to an entity.
 type PolicyData struct {
-	DisapprovalReasons []DisapprovalReason `xml:"https://adwords.google.com/api/adwords/cm/v201609 disapprovalReasons,omitempty"`
-	PolicyDataType     string              `xml:"https://adwords.google.com/api/adwords/cm/v201609 PolicyData.Type,omitempty"`
+	DisapprovalReasons []DisapprovalReason `xml:"https://adwords.google.com/api/adwords/cm/v201708 disapprovalReasons,omitempty"`
+	PolicyDataType     string              `xml:"https://adwords.google.com/api/adwords/cm/v201708 PolicyData.Type,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.DisapprovalReason
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.DisapprovalReason
 // Container for information about why an AdWords entity was disapproved.
 type DisapprovalReason struct {
-	ShortName string `xml:"https://adwords.google.com/api/adwords/cm/v201609 shortName,omitempty"`
+	ShortName string `xml:"https://adwords.google.com/api/adwords/cm/v201708 shortName,omitempty"`
 }
 
 // error parsers

--- a/batch_job.go
+++ b/batch_job.go
@@ -20,7 +20,7 @@ type BatchJobOperations struct {
 }
 
 type Operation struct {
-	Operator string      `xml:"https://adwords.google.com/api/adwords/cm/v201609 operator"`
+	Operator string      `xml:"https://adwords.google.com/api/adwords/cm/v201708 operator"`
 	Operand  interface{} `xml:"operand"`
 	Xsi_type string      `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
 }
@@ -93,7 +93,7 @@ func NewBatchJobService(auth *Auth) *BatchJobService {
 //		},
 //	)
 //
-// 	https://developers.google.com/adwords/api/docs/reference/v201609/BatchJobService#get
+// 	https://developers.google.com/adwords/api/docs/reference/v201708/BatchJobService#get
 func (s *BatchJobService) Get(selector Selector) (batchJobPage BatchJobPage, err error) {
 
 	selector.XMLName = xml.Name{baseUrl, "selector"}
@@ -136,7 +136,7 @@ func (s *BatchJobService) Get(selector Selector) (batchJobPage BatchJobPage, err
 //		},
 //	)
 //
-// 	https://developers.google.com/adwords/api/docs/reference/v201609/BatchJobService#mutate
+// 	https://developers.google.com/adwords/api/docs/reference/v201708/BatchJobService#mutate
 func (s *BatchJobService) Mutate(batchJobOperations BatchJobOperations) (batchJobs []BatchJob, err error) {
 
 	mutation := struct {

--- a/campaign.go
+++ b/campaign.go
@@ -83,10 +83,10 @@ func NewTrackingSetting(trackingUrl string) CampaignSetting {
 }
 
 type NetworkSetting struct {
-	TargetGoogleSearch         bool `xml:"https://adwords.google.com/api/adwords/cm/v201609 targetGoogleSearch"`
-	TargetSearchNetwork        bool `xml:"https://adwords.google.com/api/adwords/cm/v201609 targetSearchNetwork"`
-	TargetContentNetwork       bool `xml:"https://adwords.google.com/api/adwords/cm/v201609 targetContentNetwork"`
-	TargetPartnerSearchNetwork bool `xml:"https://adwords.google.com/api/adwords/cm/v201609 targetPartnerSearchNetwork"`
+	TargetGoogleSearch         bool `xml:"https://adwords.google.com/api/adwords/cm/v201708 targetGoogleSearch"`
+	TargetSearchNetwork        bool `xml:"https://adwords.google.com/api/adwords/cm/v201708 targetSearchNetwork"`
+	TargetContentNetwork       bool `xml:"https://adwords.google.com/api/adwords/cm/v201708 targetContentNetwork"`
+	TargetPartnerSearchNetwork bool `xml:"https://adwords.google.com/api/adwords/cm/v201708 targetPartnerSearchNetwork"`
 }
 
 type BiddingScheme struct {
@@ -184,7 +184,7 @@ type CampaignLabelOperations map[string][]CampaignLabel
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#get
+//     https://developers.google.com/adwords/api/docs/reference/v201708/CampaignService#get
 //
 func (s *CampaignService) Get(selector Selector) (campaigns []Campaign, totalCount int64, err error) {
 	// The default namespace, "", will break in 1.5 with the addition of
@@ -253,7 +253,7 @@ func (s *CampaignService) Get(selector Selector) (campaigns []Campaign, totalCou
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#mutate
+//     https://developers.google.com/adwords/api/docs/reference/v201708/CampaignService#mutate
 //
 func (s *CampaignService) Mutate(campaignOperations CampaignOperations) (campaigns []Campaign, err error) {
 	type campaignOperation struct {
@@ -312,7 +312,7 @@ func (s *CampaignService) Mutate(campaignOperations CampaignOperations) (campaig
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#mutateLabel
+//     https://developers.google.com/adwords/api/docs/reference/v201708/CampaignService#mutateLabel
 //
 func (s *CampaignService) MutateLabel(campaignLabelOperations CampaignLabelOperations) (campaignLabels []CampaignLabel, err error) {
 	type campaignLabelOperation struct {
@@ -356,7 +356,7 @@ func (s *CampaignService) MutateLabel(campaignLabelOperations CampaignLabelOpera
 
 // Query documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/CampaignService#query
+//     https://developers.google.com/adwords/api/docs/reference/v201708/CampaignService#query
 //
 func (s *CampaignService) Query(query string) (campaigns []Campaign, totalCount int64, err error) {
 

--- a/campaign_extension.go
+++ b/campaign_extension.go
@@ -12,17 +12,17 @@ func NewCampaignExtensionService(auth *Auth) *CampaignExtensionSettingService {
 	return &CampaignExtensionSettingService{Auth: *auth}
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/CampaignExtensionSettingService.CampaignExtensionSetting
+// https://developers.google.com/adwords/api/docs/reference/v201708/CampaignExtensionSettingService.CampaignExtensionSetting
 // A CampaignExtensionSetting is used to add or modify extensions being served for the specified campaign.
 type CampaignExtensionSetting struct {
-	CampaignId       int64            `xml:"https://adwords.google.com/api/adwords/cm/v201609 campaignId,omitempty"`
-	ExtensionType    FeedType         `xml:"https://adwords.google.com/api/adwords/cm/v201609 extensionType,omitempty"`
-	ExtensionSetting ExtensionSetting `xml:"https://adwords.google.com/api/adwords/cm/v201609 extensionSetting,omitempty"`
+	CampaignId       int64            `xml:"https://adwords.google.com/api/adwords/cm/v201708 campaignId,omitempty"`
+	ExtensionType    FeedType         `xml:"https://adwords.google.com/api/adwords/cm/v201708 extensionType,omitempty"`
+	ExtensionSetting ExtensionSetting `xml:"https://adwords.google.com/api/adwords/cm/v201708 extensionSetting,omitempty"`
 }
 
 type CampaignExtensionSettingOperations map[string][]CampaignExtensionSetting
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/CampaignExtensionSettingService#query
+// https://developers.google.com/adwords/api/docs/reference/v201708/CampaignExtensionSettingService#query
 func (s *CampaignExtensionSettingService) Query(query string) (settings []CampaignExtensionSetting, totalCount int64, err error) {
 	respBody, err := s.Auth.request(
 		campaignExtensionSettingUrl,
@@ -52,7 +52,7 @@ func (s *CampaignExtensionSettingService) Query(query string) (settings []Campai
 	return getResp.Settings, getResp.Size, err
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/CampaignExtensionSettingService#mutate
+// https://developers.google.com/adwords/api/docs/reference/v201708/CampaignExtensionSettingService#mutate
 func (s *CampaignExtensionSettingService) Mutate(settingsOperations CampaignExtensionSettingOperations) (settings []CampaignExtensionSetting, err error) {
 	type settingOperations struct {
 		Action  string                   `xml:"operator"`

--- a/constant_data.go
+++ b/constant_data.go
@@ -17,7 +17,7 @@ func (s *ConstantDataService) GetAgeRangeCriterion() (ageRanges []AgeRangeCriter
 		constantDataServiceUrl,
 		"getAgeRangeCriterion",
 		struct {
-			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201609 getAgeRangeCriterion"`
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201708 getAgeRangeCriterion"`
 		}{},
 		nil,
 	)
@@ -39,7 +39,7 @@ func (s *ConstantDataService) GetCarrierCriterion() (carriers []CarrierCriterion
 		constantDataServiceUrl,
 		"getCarrierCriterion",
 		struct {
-			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201609 getCarrierCriterion"`
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201708 getCarrierCriterion"`
 		}{},
 		nil,
 	)
@@ -61,7 +61,7 @@ func (s *ConstantDataService) GetGenderCriterion() (genders []GenderCriterion, e
 		constantDataServiceUrl,
 		"getGenderCriterion",
 		struct {
-			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201609 getGenderCriterion"`
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201708 getGenderCriterion"`
 		}{},
 		nil,
 	)
@@ -83,7 +83,7 @@ func (s *ConstantDataService) GetLanguageCriterion() (languages []LanguageCriter
 		constantDataServiceUrl,
 		"getLanguageCriterion",
 		struct {
-			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201609 getLanguageCriterion"`
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201708 getLanguageCriterion"`
 		}{},
 		nil,
 	)
@@ -105,7 +105,7 @@ func (s *ConstantDataService) GetMobileDeviceCriterion() (mobileDevices []Mobile
 		constantDataServiceUrl,
 		"getMobileDeviceCriterion",
 		struct {
-			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201609 getMobileDeviceCriterion"`
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201708 getMobileDeviceCriterion"`
 		}{},
 		nil,
 	)
@@ -127,7 +127,7 @@ func (s *ConstantDataService) GetOperatingSystemVersionCriterion() (operatingSys
 		constantDataServiceUrl,
 		"getOperatingSystemVersionCriterion",
 		struct {
-			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201609 getOperatingSystemVersionCriterion"`
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201708 getOperatingSystemVersionCriterion"`
 		}{},
 		nil,
 	)
@@ -153,7 +153,7 @@ func (s *ConstantDataService) GetProductBiddingCategoryCriterion(selector Select
 			Sel     Selector
 		}{
 			XMLName: xml.Name{
-				Space: "https://adwords.google.com/api/adwords/cm/v201609",
+				Space: "https://adwords.google.com/api/adwords/cm/v201708",
 				Local: "getProductBiddingCategoryData",
 			},
 			Sel: selector,
@@ -178,7 +178,7 @@ func (s *ConstantDataService) GetUserInterestCriterion() (userInterests []UserIn
 		constantDataServiceUrl,
 		"getUserInterestCriterion",
 		struct {
-			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201609 getUserInterestCriterion"`
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201708 getUserInterestCriterion"`
 		}{},
 		nil,
 	)
@@ -200,7 +200,7 @@ func (s *ConstantDataService) GetVerticalCriterion() (verticals []VerticalCriter
 		constantDataServiceUrl,
 		"getVerticalCriterion",
 		struct {
-			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201609 getVerticalCriterion"`
+			XMLName xml.Name `xml:"https://adwords.google.com/api/adwords/cm/v201708 getVerticalCriterion"`
 		}{},
 		nil,
 	)

--- a/criterion.go
+++ b/criterion.go
@@ -42,57 +42,57 @@ type GenderCriterion struct {
 }
 
 type KeywordCriterion struct {
-	Id        int64  `xml:"https://adwords.google.com/api/adwords/cm/v201609 id,omitempty"`
-	Text      string `xml:"https://adwords.google.com/api/adwords/cm/v201609 text,omitempty"`      // Text: up to 80 characters and ten words
-	MatchType string `xml:"https://adwords.google.com/api/adwords/cm/v201609 matchType,omitempty"` // MatchType:  "EXACT", "PHRASE", "BROAD"
+	Id        int64  `xml:"https://adwords.google.com/api/adwords/cm/v201708 id,omitempty"`
+	Text      string `xml:"https://adwords.google.com/api/adwords/cm/v201708 text,omitempty"`      // Text: up to 80 characters and ten words
+	MatchType string `xml:"https://adwords.google.com/api/adwords/cm/v201708 matchType,omitempty"` // MatchType:  "EXACT", "PHRASE", "BROAD"
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.Keyword
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.Keyword
 // Represents a keyword.
 type Keyword struct {
-	Id            int64         `xml:"https://adwords.google.com/api/adwords/cm/v201609 id,omitempty"`
-	Type          CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201609 type,omitempty"`
-	CriterionType CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201609 Criterion.Type,omitempty"`
+	Id            int64         `xml:"https://adwords.google.com/api/adwords/cm/v201708 id,omitempty"`
+	Type          CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201708 type,omitempty"`
+	CriterionType CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201708 Criterion.Type,omitempty"`
 
-	Text      string           `xml:"https://adwords.google.com/api/adwords/cm/v201609 text,omitempty"`
-	MatchType KeywordMatchType `xml:"https://adwords.google.com/api/adwords/cm/v201609 matchType,omitempty"`
+	Text      string           `xml:"https://adwords.google.com/api/adwords/cm/v201708 text,omitempty"`
+	MatchType KeywordMatchType `xml:"https://adwords.google.com/api/adwords/cm/v201708 matchType,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.KeywordMatchType
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.KeywordMatchType
 // Match type of a keyword. i.e. the way we match a keyword string with search queries.
 // EXACT, PHRASE, BROAD
 type KeywordMatchType string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.Criterion.Type
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.Criterion.Type
 // The types of criteria
 type CriterionType string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.LocationTargetingStatus
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.LocationTargetingStatus
 // Enum that represents the different Targeting Status values for a Location criterion.
 // ACTIVE, OBSOLETE, PHASING_OUT
 type LocationTargetingStatus string
 
 type LanguageCriterion struct {
-	Id   int64  `xml:"https://adwords.google.com/api/adwords/cm/v201609 id,omitempty"`
-	Code string `xml:"https://adwords.google.com/api/adwords/cm/v201609 code,omitempty"`
-	Name string `xml:"https://adwords.google.com/api/adwords/cm/v201609 name,omitempty"`
+	Id   int64  `xml:"https://adwords.google.com/api/adwords/cm/v201708 id,omitempty"`
+	Code string `xml:"https://adwords.google.com/api/adwords/cm/v201708 code,omitempty"`
+	Name string `xml:"https://adwords.google.com/api/adwords/cm/v201708 name,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.Location
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.Location
 // Represents Location criterion.  A criterion of this type can only be created using an ID.
 // LocationName:
 // DisplayType:
 // TargetingStatus: ACTIVE, OBSOLETE, PHASING_OUT
 // ParentLocations:
 type Location struct {
-	Id            int64         `xml:"https://adwords.google.com/api/adwords/cm/v201609 id,omitempty"`
-	Type          CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201609 type,omitempty"`
-	CriterionType CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201609 Criterion.Type,omitempty"`
+	Id            int64         `xml:"https://adwords.google.com/api/adwords/cm/v201708 id,omitempty"`
+	Type          CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201708 type,omitempty"`
+	CriterionType CriterionType `xml:"https://adwords.google.com/api/adwords/cm/v201708 Criterion.Type,omitempty"`
 
-	LocationName    string                  `xml:"https://adwords.google.com/api/adwords/cm/v201609 locationName,omitempty"`
-	DisplayType     string                  `xml:"https://adwords.google.com/api/adwords/cm/v201609 displayType,omitempty"`
-	TargetingStatus LocationTargetingStatus `xml:"https://adwords.google.com/api/adwords/cm/v201609 targetingStatus,omitempty"`
-	ParentLocations []Location              `xml:"https://adwords.google.com/api/adwords/cm/v201609 parentLocations,omitempty"`
+	LocationName    string                  `xml:"https://adwords.google.com/api/adwords/cm/v201708 locationName,omitempty"`
+	DisplayType     string                  `xml:"https://adwords.google.com/api/adwords/cm/v201708 displayType,omitempty"`
+	TargetingStatus LocationTargetingStatus `xml:"https://adwords.google.com/api/adwords/cm/v201708 targetingStatus,omitempty"`
+	ParentLocations []Location              `xml:"https://adwords.google.com/api/adwords/cm/v201708 parentLocations,omitempty"`
 }
 
 // MobileAppCategoryId:

--- a/customer.go
+++ b/customer.go
@@ -11,7 +11,6 @@ type Customer struct {
 	CurrencyCode               string                     `xml:"currencyCode,omitempty"`
 	DateTimeZone               string                     `xml:"dateTimeZone,omitempty"`
 	DescriptiveName            string                     `xml:"descriptiveName,omitempty"`
-	CompanyName                string                     `xml:"companyName,omitempty"`
 	CanManageClients           bool                       `xml:"canManageClients,omitempty"`
 	IsTestAccount              bool                       `xml:"testAccount,omitempty"`
 	AutoTaggingEnabled         bool                       `xml:"autoTaggingEnabled,omitempty"`

--- a/data.go
+++ b/data.go
@@ -71,8 +71,8 @@ type CriterionBidLandscape struct {
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/DataService#getadgroupbidlandscape
-//	   https://developers.google.com/adwords/api/docs/appendix/selectorfields#v201609-DataService
+//     https://developers.google.com/adwords/api/docs/reference/v201708/DataService#getadgroupbidlandscape
+//	   https://developers.google.com/adwords/api/docs/appendix/selectorfields#v201708-DataService
 //
 func (s *DataService) GetAdGroupBidLandscape(selector Selector) (adGroupBidLandscapes []AdGroupBidLandscape, totalCount int64, err error) {
 	// The default namespace, "", will break in 1.5 with the addition of
@@ -141,8 +141,8 @@ func (s *DataService) GetAdGroupBidLandscape(selector Selector) (adGroupBidLands
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/DataService#getcriterionbidlandscape
-//	   https://developers.google.com/adwords/api/docs/appendix/selectorfields#v201609-DataService
+//     https://developers.google.com/adwords/api/docs/reference/v201708/DataService#getcriterionbidlandscape
+//	   https://developers.google.com/adwords/api/docs/appendix/selectorfields#v201708-DataService
 //
 func (s *DataService) GetCriterionBidLandscape(selector Selector) (criterionBidLandscapes []CriterionBidLandscape, totalCount int64, err error) {
 	// The default namespace, "", will break in 1.5 with the addition of
@@ -183,7 +183,7 @@ func (s *DataService) GetCriterionBidLandscape(selector Selector) (criterionBidL
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/DataService#queryadgroupbidlandscape
+//     https://developers.google.com/adwords/api/docs/reference/v201708/DataService#queryadgroupbidlandscape
 //
 func (s *DataService) QueryAdGroupBidLandscape(query string) (adGroupBidLandscapes []AdGroupBidLandscape, totalCount int64, err error) {
 
@@ -220,7 +220,7 @@ func (s *DataService) QueryAdGroupBidLandscape(query string) (adGroupBidLandscap
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201609/DataService#querycriterionbidlandscape
+//     https://developers.google.com/adwords/api/docs/reference/v201708/DataService#querycriterionbidlandscape
 //
 func (s *DataService) QueryCriterionBidLandscape(query string) (criterionBidLandscapes []CriterionBidLandscape, totalCount int64, err error) {
 

--- a/extension_setting.go
+++ b/extension_setting.go
@@ -5,54 +5,54 @@ import (
 	"fmt"
 )
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.ExtensionSetting
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.ExtensionSetting
 // A setting specifying when and which extensions should serve at a given level (customer, campaign, or ad group).
 type ExtensionSetting struct {
 	PlatformRestrictions ExtensionSettingPlatform `xml:"platformRestrictions,omitempty"`
 
-	Extensions Extension `xml:"https://adwords.google.com/api/adwords/cm/v201609 extensions,omitempty"`
+	Extensions Extension `xml:"https://adwords.google.com/api/adwords/cm/v201708 extensions,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.ExtensionSetting.Platform
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.ExtensionSetting.Platform
 // Different levels of platform restrictions
 // DESKTOP, MOBILE, NONE
 type ExtensionSettingPlatform string
 
 type Extension interface{}
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.ExtensionFeedItem
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.ExtensionFeedItem
 // Contains base extension feed item data for an extension in an extension feed managed by AdWords.
 type ExtensionFeedItem struct {
 	XMLName xml.Name `json:"-" xml:"extensions"`
 
-	FeedId                  int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201609 feedId,omitempty"`
-	FeedItemId              int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201609 feedItemId,omitempty"`
-	Status                  *FeedItemStatus            `xml:"https://adwords.google.com/api/adwords/cm/v201609 status,omitempty"`
-	FeedType                *FeedType                  `xml:"https://adwords.google.com/api/adwords/cm/v201609 feedType,omitempty"`
-	StartTime               string                     `xml:"https://adwords.google.com/api/adwords/cm/v201609 startTime,omitempty"` //  special value "00000101 000000" may be used to clear an existing start time.
-	EndTime                 string                     `xml:"https://adwords.google.com/api/adwords/cm/v201609 endTime,omitempty"`   //  special value "00000101 000000" may be used to clear an existing end time.
-	DevicePreference        *FeedItemDevicePreference  `xml:"https://adwords.google.com/api/adwords/cm/v201609 devicePreference,omitempty"`
-	Scheduling              *FeedItemScheduling        `xml:"https://adwords.google.com/api/adwords/cm/v201609 scheduling,omitempty"`
-	CampaignTargeting       *FeedItemCampaignTargeting `xml:"https://adwords.google.com/api/adwords/cm/v201609 campaignTargeting,omitempty"`
-	AdGroupTargeting        *FeedItemAdGroupTargeting  `xml:"https://adwords.google.com/api/adwords/cm/v201609 adGroupTargeting,omitempty"`
-	KeywordTargeting        *Keyword                   `xml:"https://adwords.google.com/api/adwords/cm/v201609 keywordTargeting,omitempty"`
-	GeoTargeting            *Location                  `xml:"https://adwords.google.com/api/adwords/cm/v201609 geoTargeting,omitempty"`
-	GeoTargetingRestriction *FeedItemGeoRestriction    `xml:"https://adwords.google.com/api/adwords/cm/v201609 geoTargetingRestriction,omitempty"`
-	PolicyData              *[]FeedItemPolicyData      `xml:"https://adwords.google.com/api/adwords/cm/v201609 policyData,omitempty"`
+	FeedId                  int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201708 feedId,omitempty"`
+	FeedItemId              int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201708 feedItemId,omitempty"`
+	Status                  *FeedItemStatus            `xml:"https://adwords.google.com/api/adwords/cm/v201708 status,omitempty"`
+	FeedType                *FeedType                  `xml:"https://adwords.google.com/api/adwords/cm/v201708 feedType,omitempty"`
+	StartTime               string                     `xml:"https://adwords.google.com/api/adwords/cm/v201708 startTime,omitempty"` //  special value "00000101 000000" may be used to clear an existing start time.
+	EndTime                 string                     `xml:"https://adwords.google.com/api/adwords/cm/v201708 endTime,omitempty"`   //  special value "00000101 000000" may be used to clear an existing end time.
+	DevicePreference        *FeedItemDevicePreference  `xml:"https://adwords.google.com/api/adwords/cm/v201708 devicePreference,omitempty"`
+	Scheduling              *FeedItemScheduling        `xml:"https://adwords.google.com/api/adwords/cm/v201708 scheduling,omitempty"`
+	CampaignTargeting       *FeedItemCampaignTargeting `xml:"https://adwords.google.com/api/adwords/cm/v201708 campaignTargeting,omitempty"`
+	AdGroupTargeting        *FeedItemAdGroupTargeting  `xml:"https://adwords.google.com/api/adwords/cm/v201708 adGroupTargeting,omitempty"`
+	KeywordTargeting        *Keyword                   `xml:"https://adwords.google.com/api/adwords/cm/v201708 keywordTargeting,omitempty"`
+	GeoTargeting            *Location                  `xml:"https://adwords.google.com/api/adwords/cm/v201708 geoTargeting,omitempty"`
+	GeoTargetingRestriction *FeedItemGeoRestriction    `xml:"https://adwords.google.com/api/adwords/cm/v201708 geoTargetingRestriction,omitempty"`
+	PolicyData              *[]FeedItemPolicyData      `xml:"https://adwords.google.com/api/adwords/cm/v201708 policyData,omitempty"`
 
-	ExtensionFeedItemType string `xml:"https://adwords.google.com/api/adwords/cm/v201609 ExtensionFeedItem.Type,omitempty"`
+	ExtensionFeedItemType string `xml:"https://adwords.google.com/api/adwords/cm/v201708 ExtensionFeedItem.Type,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.CallFeedItem
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.CallFeedItem
 // Represents a Call extension.
 type CallFeedItem struct {
 	ExtensionFeedItem
 
-	CallPhoneNumber               string             `xml:"https://adwords.google.com/api/adwords/cm/v201609 callPhoneNumber,omitempty"`
-	CallCountryCode               string             `xml:"https://adwords.google.com/api/adwords/cm/v201609 callCountryCode,omitempty"`
-	CallTracking                  bool               `xml:"https://adwords.google.com/api/adwords/cm/v201609 callTracking,omitempty"`
-	CallConversionType            CallConversionType `xml:"https://adwords.google.com/api/adwords/cm/v201609 callConversionType,omitempty"`
-	DisableCallConversionTracking bool               `xml:"https://adwords.google.com/api/adwords/cm/v201609 disableCallConversionTracking,omitempty"`
+	CallPhoneNumber               string             `xml:"https://adwords.google.com/api/adwords/cm/v201708 callPhoneNumber,omitempty"`
+	CallCountryCode               string             `xml:"https://adwords.google.com/api/adwords/cm/v201708 callCountryCode,omitempty"`
+	CallTracking                  bool               `xml:"https://adwords.google.com/api/adwords/cm/v201708 callTracking,omitempty"`
+	CallConversionType            CallConversionType `xml:"https://adwords.google.com/api/adwords/cm/v201708 callConversionType,omitempty"`
+	DisableCallConversionTracking bool               `xml:"https://adwords.google.com/api/adwords/cm/v201708 disableCallConversionTracking,omitempty"`
 }
 
 func extensionsUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (ext interface{}, err error) {
@@ -75,7 +75,7 @@ func (s ExtensionSetting) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 	e.EncodeToken(start)
 	if s.PlatformRestrictions != "NONE" {
 		e.EncodeElement(&s.PlatformRestrictions, xml.StartElement{Name: xml.Name{
-			"https://adwords.google.com/api/adwords/cm/v201609",
+			"https://adwords.google.com/api/adwords/cm/v201708",
 			"platformRestrictions"}})
 	}
 	switch extType := s.Extensions.(type) {

--- a/feed.go
+++ b/feed.go
@@ -10,7 +10,7 @@ func NewFeedService(auth *Auth) *FeedService {
 	return &FeedService{Auth: *auth}
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/FeedService
+// https://developers.google.com/adwords/api/docs/reference/v201708/FeedService
 func (s *FeedService) Query(query string) (page []Feed, totalCount int64, err error) {
 	respBody, err := s.Auth.request(
 		feedServiceUrl,
@@ -39,50 +39,50 @@ func (s *FeedService) Query(query string) (page []Feed, totalCount int64, err er
 	return getResp.Feeds, getResp.Size, err
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.Feed.Type
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.Feed.Type
 // Feed hard type. Values coincide with placeholder type id.
 // Enum: NONE, SITELINK, CALL, APP, REVIEW, AD_CUSTOMIZER, CALLOUT, STRUCTURED_SNIPPET, PRICE
 type FeedType string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/FeedService.Feed.Status
+// https://developers.google.com/adwords/api/docs/reference/v201708/FeedService.Feed.Status
 // Status of the Feed.
 // ENABLED, REMOVED, UNKNOWN
 type FeedStatus string
 
 // Used to Specify who manages the FeedAttributes for the Feed.
-// https://developers.google.com/adwords/api/docs/reference/v201609/FeedService.Feed.Origin
+// https://developers.google.com/adwords/api/docs/reference/v201708/FeedService.Feed.Origin
 // USER, ADWORDS, UNKNOWN
 type FeedOrigin string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/FeedService.FeedAttribute.Type
+// https://developers.google.com/adwords/api/docs/reference/v201708/FeedService.FeedAttribute.Type
 // Possible data types.
 type FeedAttributeType string
 
 // Configuration data allowing feed items to be populated for a system feed.
-// https://developers.google.com/adwords/api/docs/reference/v201609/FeedService.SystemFeedGenerationData
+// https://developers.google.com/adwords/api/docs/reference/v201708/FeedService.SystemFeedGenerationData
 type SystemFeedGenerationData struct {
-	SystemFeedGenerationDataType string `xml:"https://adwords.google.com/api/adwords/cm/v201609 SystemFeedGenerationData.Type,omitempty"`
+	SystemFeedGenerationDataType string `xml:"https://adwords.google.com/api/adwords/cm/v201708 SystemFeedGenerationData.Type,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/FeedService.FeedAttribute
+// https://developers.google.com/adwords/api/docs/reference/v201708/FeedService.FeedAttribute
 // FeedAttributes define the types of data expected to be present in a Feed.
 // A single FeedAttribute specifies the expected type of the FeedItemAttributes with the same FeedAttributeId.
 // Optionally, a FeedAttribute can be marked as being part of a FeedItem's unique key.
 type FeedAttribute struct {
-	Id          int64             `xml:"https://adwords.google.com/api/adwords/cm/v201609 id,omitempty"`
-	Name        string            `xml:"https://adwords.google.com/api/adwords/cm/v201609 name,omitempty"`
-	Type        FeedAttributeType `xml:"https://adwords.google.com/api/adwords/cm/v201609 type,omitempty"`
-	IsPartOfKey bool              `xml:"https://adwords.google.com/api/adwords/cm/v201609 isPartOfKey,omitempty"`
+	Id          int64             `xml:"https://adwords.google.com/api/adwords/cm/v201708 id,omitempty"`
+	Name        string            `xml:"https://adwords.google.com/api/adwords/cm/v201708 name,omitempty"`
+	Type        FeedAttributeType `xml:"https://adwords.google.com/api/adwords/cm/v201708 type,omitempty"`
+	IsPartOfKey bool              `xml:"https://adwords.google.com/api/adwords/cm/v201708 isPartOfKey,omitempty"`
 }
 
 // A Feed identifies a source of data and its schema.
 // The data for the Feed can either be user-entered via the FeedItemService or system-generated, in which case the data is provided automatically.
-// https://developers.google.com/adwords/api/docs/reference/v201609/FeedService.Feed
+// https://developers.google.com/adwords/api/docs/reference/v201708/FeedService.Feed
 type Feed struct {
-	Id                       int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201609 id,omitempty"`
-	Name                     string                     `xml:"https://adwords.google.com/api/adwords/cm/v201609 name,omitempty"`
-	Attributes               []FeedAttribute            `xml:"https://adwords.google.com/api/adwords/cm/v201609 attributes,omitempty"`
-	Status                   FeedStatus                 `xml:"https://adwords.google.com/api/adwords/cm/v201609 status,omitempty"`
-	Origin                   FeedOrigin                 `xml:"https://adwords.google.com/api/adwords/cm/v201609 origin,omitempty"`
-	SystemFeedGenerationData []SystemFeedGenerationData `xml:"https://adwords.google.com/api/adwords/cm/v201609 systemFeedGenerationData,omitempty"`
+	Id                       int64                      `xml:"https://adwords.google.com/api/adwords/cm/v201708 id,omitempty"`
+	Name                     string                     `xml:"https://adwords.google.com/api/adwords/cm/v201708 name,omitempty"`
+	Attributes               []FeedAttribute            `xml:"https://adwords.google.com/api/adwords/cm/v201708 attributes,omitempty"`
+	Status                   FeedStatus                 `xml:"https://adwords.google.com/api/adwords/cm/v201708 status,omitempty"`
+	Origin                   FeedOrigin                 `xml:"https://adwords.google.com/api/adwords/cm/v201708 origin,omitempty"`
+	SystemFeedGenerationData []SystemFeedGenerationData `xml:"https://adwords.google.com/api/adwords/cm/v201708 systemFeedGenerationData,omitempty"`
 }

--- a/feed_item.go
+++ b/feed_item.go
@@ -8,97 +8,97 @@ func NewFeedItemService(auth *Auth) *FeedItemService {
 	return &FeedItemService{Auth: *auth}
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItem.Status
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItem.Status
 // ENABLED, REMOVED, UNKNOWN
 type FeedItemStatus string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemDevicePreference
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemDevicePreference
 // Represents a FeedItem device preference
 type FeedItemDevicePreference struct {
-	DevicePreference int64 `xml:"https://adwords.google.com/api/adwords/cm/v201609 devicePreference,omitempty"`
+	DevicePreference int64 `xml:"https://adwords.google.com/api/adwords/cm/v201708 devicePreference,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemScheduling
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemScheduling
 // Represents a collection of FeedItem schedules specifying all time intervals for which the feed item may serve.
 // Any time range not covered by the specified FeedItemSchedules will prevent the feed item from serving during those times.
 type FeedItemScheduling struct {
-	feedItemSchedules int64 `xml:"https://adwords.google.com/api/adwords/cm/v201609 feedItemSchedules,omitempty"`
+	feedItemSchedules int64 `xml:"https://adwords.google.com/api/adwords/cm/v201708 feedItemSchedules,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemSchedule
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemSchedule
 // Represents a FeedItem schedule, which specifies a time interval on a given day when the feed item may serve.
 // The FeedItemSchedule times are in the account's time zone.
 type FeedItemSchedule struct {
-	DayOfWeek   DayOfWeek    `xml:"https://adwords.google.com/api/adwords/cm/v201609 dayOfWeek,omitempty"`
-	StartHour   int          `xml:"https://adwords.google.com/api/adwords/cm/v201609 startHour,omitempty"`
-	StartMinute MinuteOfHour `xml:"https://adwords.google.com/api/adwords/cm/v201609 startMinute,omitempty"`
-	EndHour     int          `xml:"https://adwords.google.com/api/adwords/cm/v201609 endHour,omitempty"`
-	EndMinute   MinuteOfHour `xml:"https://adwords.google.com/api/adwords/cm/v201609 endMinute,omitempty"`
+	DayOfWeek   DayOfWeek    `xml:"https://adwords.google.com/api/adwords/cm/v201708 dayOfWeek,omitempty"`
+	StartHour   int          `xml:"https://adwords.google.com/api/adwords/cm/v201708 startHour,omitempty"`
+	StartMinute MinuteOfHour `xml:"https://adwords.google.com/api/adwords/cm/v201708 startMinute,omitempty"`
+	EndHour     int          `xml:"https://adwords.google.com/api/adwords/cm/v201708 endHour,omitempty"`
+	EndMinute   MinuteOfHour `xml:"https://adwords.google.com/api/adwords/cm/v201708 endMinute,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemCampaignTargeting
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemCampaignTargeting
 // Specifies the campaign the request context must match in order for the feed item to be considered eligible for serving (aka the targeted campaign).
 // E.g., if the below campaign targeting is set to campaignId = X, then the feed item can only serve under campaign X.
 type FeedItemCampaignTargeting struct {
-	TargetingCampaignId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201609 TargetingCampaignId,omitempty"`
+	TargetingCampaignId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201708 TargetingCampaignId,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemAdGroupTargeting
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemAdGroupTargeting
 // Specifies the adgroup the request context must match in order for the feed item to be considered eligible for serving (aka the targeted adgroup).
 // E.g., if the below adgroup targeting is set to adgroup = X, then the feed item can only serve under adgroup X.
 type FeedItemAdGroupTargeting struct {
-	TargetingAdGroupId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201609 TargetingAdGroupId,omitempty"`
+	TargetingAdGroupId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201708 TargetingAdGroupId,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemGeoRestriction
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemGeoRestriction
 // Represents a FeedItem geo restriction.
 type FeedItemGeoRestriction struct {
-	GeoRestriction GeoRestriction `xml:"https://adwords.google.com/api/adwords/cm/v201609 geoRestriction,omitempty"`
+	GeoRestriction GeoRestriction `xml:"https://adwords.google.com/api/adwords/cm/v201708 geoRestriction,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemPolicyData
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemPolicyData
 // Contains offline-validation and approval results for a given FeedItem and FeedMapping.
 // Each validation data indicates any issues found on the feed item when used in the context of the feed mapping.
 type FeedItemPolicyData struct {
 	PolicyData
-	PlaceholderType           int                               `xml:"https://adwords.google.com/api/adwords/cm/v201609 placeholderType,omitempty"`
-	FeedMappingId             int64                             `xml:"https://adwords.google.com/api/adwords/cm/v201609 feedMappingId,omitempty"`
-	ValidationStatus          FeedItemValidationStatus          `xml:"https://adwords.google.com/api/adwords/cm/v201609 validationStatus,omitempty"`
-	ApprovalStatus            FeedItemApprovalStatus            `xml:"https://adwords.google.com/api/adwords/cm/v201609 approvalStatus,omitempty"`
-	ValidationErrors          []FeedItemAttributeError          `xml:"https://adwords.google.com/api/adwords/cm/v201609 validationErrors,omitempty"`
-	QualityApprovalStatus     FeedItemQualityApprovalStatus     `xml:"https://adwords.google.com/api/adwords/cm/v201609 qualityApprovalStatus,omitempty"`
-	QualityDisapprovalReasons FeedItemQualityDisapprovalReasons `xml:"https://adwords.google.com/api/adwords/cm/v201609 qualityDisapprovalReasons,omitempty"`
+	PlaceholderType           int                               `xml:"https://adwords.google.com/api/adwords/cm/v201708 placeholderType,omitempty"`
+	FeedMappingId             int64                             `xml:"https://adwords.google.com/api/adwords/cm/v201708 feedMappingId,omitempty"`
+	ValidationStatus          FeedItemValidationStatus          `xml:"https://adwords.google.com/api/adwords/cm/v201708 validationStatus,omitempty"`
+	ApprovalStatus            FeedItemApprovalStatus            `xml:"https://adwords.google.com/api/adwords/cm/v201708 approvalStatus,omitempty"`
+	ValidationErrors          []FeedItemAttributeError          `xml:"https://adwords.google.com/api/adwords/cm/v201708 validationErrors,omitempty"`
+	QualityApprovalStatus     FeedItemQualityApprovalStatus     `xml:"https://adwords.google.com/api/adwords/cm/v201708 qualityApprovalStatus,omitempty"`
+	QualityDisapprovalReasons FeedItemQualityDisapprovalReasons `xml:"https://adwords.google.com/api/adwords/cm/v201708 qualityDisapprovalReasons,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemValidationStatus
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemValidationStatus
 // Validation status of a FeedItem
 // UNCHECKED, ERROR, VALID
 type FeedItemValidationStatus string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemApprovalStatus
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemApprovalStatus
 // Feed item approval status
 // UNCHECKED, APPROVED, DISAPPROVED
 type FeedItemApprovalStatus string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemAttributeError
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemAttributeError
 // Contains validation error details for a set of feed attributes
 type FeedItemAttributeError struct {
-	FeedAttributeIds    []int64 `xml:"https://adwords.google.com/api/adwords/cm/v201609 feedAttributeIds,omitempty"`
-	ValidationErrorCode int     `xml:"https://adwords.google.com/api/adwords/cm/v201609 validationErrorCode,omitempty"`
-	ErrorInformation    string  `xml:"https://adwords.google.com/api/adwords/cm/v201609 errorInformation,omitempty"`
+	FeedAttributeIds    []int64 `xml:"https://adwords.google.com/api/adwords/cm/v201708 feedAttributeIds,omitempty"`
+	ValidationErrorCode int     `xml:"https://adwords.google.com/api/adwords/cm/v201708 validationErrorCode,omitempty"`
+	ErrorInformation    string  `xml:"https://adwords.google.com/api/adwords/cm/v201708 errorInformation,omitempty"`
 }
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemQualityApprovalStatus
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemQualityApprovalStatus
 // Feed item quality evaluation approval status
 // UNCHECKED, APPROVED, DISAPPROVED
 type FeedItemQualityApprovalStatus string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.FeedItemQualityDisapprovalReasons
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.FeedItemQualityDisapprovalReasons
 // Feed item quality evaluation disapproval reasons.
 type FeedItemQualityDisapprovalReasons string
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.CallConversionType
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.CallConversionType
 // Conversion type for a call extension.
 type CallConversionType struct {
-	ConversionTypeId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201609 conversionTypeId,omitempty"`
+	ConversionTypeId int64 `xml:"https://adwords.google.com/api/adwords/cm/v201708 conversionTypeId,omitempty"`
 }

--- a/label.go
+++ b/label.go
@@ -53,7 +53,7 @@ type LabelOperations map[string][]Label
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/LabelService#get
+//     https://developers.google.com/adwords/api/docs/reference/v201708/LabelService#get
 //
 func (s LabelService) Get(selector Selector) (labels []Label, totalCount int64, err error) {
 	selector.XMLName = xml.Name{baseUrl, "serviceSelector"}
@@ -108,7 +108,7 @@ func (s LabelService) Get(selector Selector) (labels []Label, totalCount int64, 
 //
 // Relevant documentation
 //
-//     https://developers.google.com/adwords/api/docs/reference/v201409/LabelService#mutate
+//     https://developers.google.com/adwords/api/docs/reference/v201708/LabelService#mutate
 //
 func (s *LabelService) Mutate(labelOperations LabelOperations) (labels []Label, err error) {
 	type labelOperation struct {

--- a/managed_customer.go
+++ b/managed_customer.go
@@ -73,7 +73,7 @@ func (s *ManagedCustomerService) Get(selector Selector) (managedCustomerPage Man
 
 func (s *ManagedCustomerService) Mutate(managedCustomerOperations ManagedCustomerOperations) (managedCustomers []ManagedCustomer, err error) {
 	type managedCustomerOperation struct {
-		Action          string          `xml:"https://adwords.google.com/api/adwords/cm/v201609 operator"`
+		Action          string          `xml:"https://adwords.google.com/api/adwords/cm/v201708 operator"`
 		ManagedCustomer ManagedCustomer `xml:"operand"`
 	}
 

--- a/page.go
+++ b/page.go
@@ -1,8 +1,8 @@
 package gads
 
-// https://developers.google.com/adwords/api/docs/reference/v201609/AdGroupExtensionSettingService.Page
+// https://developers.google.com/adwords/api/docs/reference/v201708/AdGroupExtensionSettingService.Page
 // Contains the results from a get call.
 type Page struct {
-	TotalNumEntries int    `xml:"https://adwords.google.com/api/adwords/cm/v201609 totalNumEntries,omitempty"`
-	PageType        string `xml:"https://adwords.google.com/api/adwords/cm/v201609 Page.Type,omitempty"`
+	TotalNumEntries int    `xml:"https://adwords.google.com/api/adwords/cm/v201708 totalNumEntries,omitempty"`
+	PageType        string `xml:"https://adwords.google.com/api/adwords/cm/v201708 Page.Type,omitempty"`
 }

--- a/targeting_idea.go
+++ b/targeting_idea.go
@@ -17,7 +17,7 @@ func NewTargetingIdeaService(auth *Auth) *TargetingIdeaService {
 }
 
 // TargetingIdeaSelector A descriptor for finding TargetingIdeas that match the specified criteria.
-// https://developers.google.com/adwords/api/docs/reference/v201609/TargetingIdeaService.TargetingIdeaSelector
+// https://developers.google.com/adwords/api/docs/reference/v201708/TargetingIdeaService.TargetingIdeaSelector
 type TargetingIdeaSelector struct {
 	SearchParameters        []SearchParameter `xml:"searchParameters"`
 	IdeaType                string            `xml:"ideaType"`
@@ -279,7 +279,7 @@ func searchParameterMarshalXML(sp SearchParameter, e *xml.Encoder) error {
 }
 
 // Get Returns a page of ideas that match the query described by the specified TargetingIdeaSelector.
-// https://developers.google.com/adwords/api/docs/reference/v201609/TargetingIdeaService
+// https://developers.google.com/adwords/api/docs/reference/v201708/TargetingIdeaService
 func (s *TargetingIdeaService) Get(selector TargetingIdeaSelector) (targetingIdeas []TargetingIdeas, totalCount int64, err error) {
 
 	respBody, err := s.Auth.request(

--- a/traffic_estimator.go
+++ b/traffic_estimator.go
@@ -16,7 +16,7 @@ type KeywordEstimateRequest struct {
 
 type AdGroupEstimateRequest struct {
 	KeywordEstimateRequests []KeywordEstimateRequest `xml:"keywordEstimateRequests"`
-	MaxCpc                  int64                    `xml:"https://adwords.google.com/api/adwords/cm/v201609 maxCpc>microAmount"`
+	MaxCpc                  int64                    `xml:"https://adwords.google.com/api/adwords/cm/v201708 maxCpc>microAmount"`
 }
 
 type CampaignEstimateRequest struct {
@@ -107,7 +107,7 @@ type CampaignEstimate struct {
 //
 // Relevant documentation
 //
-// 		https://developers.google.com/adwords/api/docs/reference/v201609/TrafficEstimatorService#get
+// 		https://developers.google.com/adwords/api/docs/reference/v201708/TrafficEstimatorService#get
 //
 func (s *TrafficEstimatorService) Get(selector TrafficEstimatorSelector) (res []CampaignEstimate, err error) {
 


### PR DESCRIPTION
Closely followed migration guides from v201609 onwards:
https://developers.google.com/adwords/api/docs/guides/migration/v201702
https://developers.google.com/adwords/api/docs/guides/migration/v201705
https://developers.google.com/adwords/api/docs/guides/migration/v201708