### PR TITLE
Properly close resources with defer

### DIFF
--- a/base.go
+++ b/base.go
@@ -222,10 +222,10 @@ func (a *Auth) request(serviceUrl ServiceUrl, action string, body interface{}, o
 	req.Header.Add("Content-Type", "text/xml;charset=UTF-8")
 	req.Header.Add("SOAPAction", action)
 	resp, err := a.Client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		return []byte{}, err
 	}
+	defer resp.Body.Close()
 
 	respBody, err = ioutil.ReadAll(resp.Body)
 	if a.Testing != nil {

--- a/base.go
+++ b/base.go
@@ -206,6 +206,7 @@ func (a *Auth) request(serviceUrl ServiceUrl, action string, body interface{}, o
 	}
 
 	r, w := io.Pipe()
+	defer r.Close()
 
 	go func() {
 		w.CloseWithError(xml.NewEncoder(w).Encode(soapReqEnvelope{
@@ -221,10 +222,10 @@ func (a *Auth) request(serviceUrl ServiceUrl, action string, body interface{}, o
 	req.Header.Add("Content-Type", "text/xml;charset=UTF-8")
 	req.Header.Add("SOAPAction", action)
 	resp, err := a.Client.Do(req)
+	defer resp.Body.Close()
 	if err != nil {
 		return []byte{}, err
 	}
-	defer resp.Body.Close()
 
 	respBody, err = ioutil.ReadAll(resp.Body)
 	if a.Testing != nil {


### PR DESCRIPTION
The personas destinations team is having trouble with memory usage in one of our services. When looking at the flame graph for goroutines (example below), we see a lot of routines on `github.com/segmentio/gads.(*Auth).request.func1`, specifically waiting in the writer pipe.

<img width="1201" alt="Screen Shot 2021-05-20 at 9 20 19 PM" src="https://user-images.githubusercontent.com/1903101/119200333-9166b500-ba41-11eb-92d8-6295fd1fe57a.png">

The memory usage in our service:
![Screen Shot 2021-05-21 at 2 36 04 PM](https://user-images.githubusercontent.com/1903101/119200488-e1de1280-ba41-11eb-997f-82477edce6e5.png)

A theory is that the reader pipe is not properly closed in a few branches of the function ([example](https://github.com/segmentio/gads/blob/master/base.go#L225)). The attempt in this PR is to always close the reader pipe and thus release the memory that is stuck. It doesn't seem that we need to close the writer pipe because that is closed [right away after sending data](https://github.com/segmentio/gads/blob/a1372f00e9ffa3b70c6d6f643dd2695c97b293e6/base.go#L211-L217).

It looks like this library is only used in record: https://sourcegraph.segment.com/search?q=segmentio/gads%22&patternType=literal. I copied some people that made changes to this library recently (as in 2+ years ago 😓 ).

Relevant discussion in the golang channel: https://segment.slack.com/archives/C1WJ9B7B5/p1621627798007300